### PR TITLE
Ensure bde header is checked for each input file.

### DIFF
--- a/src/bde_copy.cpp
+++ b/src/bde_copy.cpp
@@ -1639,7 +1639,7 @@ int main( int argc, char *argv[] )
 
     for( int i = 0; i < ninfile; i++ )
     {
-        if( i ) open_bde_file(infile[i],false);
+        if( i ) open_bde_file(infile[i],true);
         if( ! copy_data(out) ) return 1;
         check_bde_size();
         close_file();


### PR DESCRIPTION
Potential fix for #3. Needs to be reviewed that this change doesn't have any implications that I might have missed.

Note this fix could be improved to deal with issue during the the first open file/ print metadata block.    See https://github.com/linz/linz_bde_copy/blob/master/src/bde_copy.cpp#L1581.  That would require storing an array of bde header sizes for each input file that could then be tested after each copy iteration. While strictly a better fix, as the metadata will get printed for each input file, I wasn't sure of the value of doing this...