### PR TITLE
Improvements in automated packaging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ on:
       - master
       - packagecloud
       - 'release-*'
-    tags:
-      - '*'
+    tags-ignore:
+      - 'debian/*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,7 @@ jobs:
         if test "${{ github.event_name }}" = 'push'; then
           if expr "${{ github.ref }}" : "refs/tags/" > /dev/null; then
             REPO=test
+            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
           else
             REPO=dev
           fi
@@ -77,7 +78,7 @@ jobs:
         echo "REPO: $REPO"
         echo ::set-env name=REPO::"$REPO"
 
-    - uses: linz/linz-software-repository@v3
+    - uses: linz/linz-software-repository@v4
       with:
         packagecloud_token: ${{ secrets.LINZCI_PACKAGECLOUD_TOKEN }}
-        publish_to_repository: ${{ env.REPO }}
+        packagecloud_repository: ${{ env.REPO }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         sudo dpkg -i ../linz-bde-copy*.deb
 
   package:
-    if: ${{ success() }}
+    needs: test
     name: Package for Debian
     runs-on: ubuntu-18.04
     strategy:


### PR DESCRIPTION
- Use linz-software-repository@v4 for updating git repo so it
  will push tag to origin and merge debian/changelog changes
  to appropriate branches.

- Ignore pushes of debian tags

- Fix conditional package based on test status